### PR TITLE
Infer currency data dynamically for inflation comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # crawl-data-stock
-Thu thập data
+
+Công cụ dòng lệnh giúp tải dữ liệu tỷ giá (Yahoo Finance) và lạm phát (FRED)
+để so sánh sức mua thực tế giữa các cặp tiền tệ từ năm 2015 đến nay.
+
+## Chuẩn bị
+
+1. Cài đặt các thư viện Python cần thiết:
+   ```bash
+   pip install pandas yfinance fredapi
+   ```
+2. Tạo FRED API key tại [https://fred.stlouisfed.org/](https://fred.stlouisfed.org/)
+   và lưu vào biến môi trường `FRED_API_KEY` (hoặc cung cấp trực tiếp khi chạy script).
+
+## Sử dụng
+
+Chạy lệnh sau và truyền vào các cặp tiền cần so sánh theo định dạng `CUR1-CUR2`:
+
+```bash
+python main.py GBP-JPY EUR-USD
+```
+
+Một vài tham số hữu ích:
+
+- `--start`: ngày bắt đầu thu thập dữ liệu (mặc định `2015-01-01`).
+- `--amount`: số tiền ban đầu tính theo đồng tiền thứ nhất trong mỗi cặp (mặc định `1000`).
+- `--fred-key`: API key nếu không đặt biến môi trường.
+- `--output`: tên file Excel đầu ra (mặc định `currency_inflation_comparison.xlsx`).
+- `--cpi-series`: (tùy chọn) ghi đè mã CPI cho từng đồng tiền khi việc tìm kiếm tự động không phù hợp, ví dụ `GBP=GBRCPIALLMINMEI`.
+
+Nếu không truyền đối số, chương trình sẽ hỏi thông tin trực tiếp trong quá trình chạy.
+
+## Kết quả
+
+Script tạo file Excel với cấu trúc:
+
+| Name | Image | 2015-01 | 2015-02 | ... |
+|------|-------|---------|---------|-----|
+| GBP  |       | ...     | ...     | ... |
+| JPY  |       | ...     | ...     | ... |
+
+Trong đó mỗi dòng thể hiện sức mua tính theo USD (đã điều chỉnh lạm phát)
+cho số tiền ban đầu ở từng đồng tiền thuộc các cặp mà bạn cung cấp.

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Nếu không truyền đối số, chương trình sẽ hỏi thông tin trực 
 
 ## Kết quả
 
-Script tạo file Excel với cấu trúc:
+Script tạo file Excel với ba sheet:
 
-| Name | Image | 2015-01 | 2015-02 | ... |
-|------|-------|---------|---------|-----|
-| GBP  |       | ...     | ...     | ... |
-| JPY  |       | ...     | ...     | ... |
-
-Trong đó mỗi dòng thể hiện sức mua tính theo USD (đã điều chỉnh lạm phát)
-cho số tiền ban đầu ở từng đồng tiền thuộc các cặp mà bạn cung cấp.
+1. **Summary** – tổng hợp tháng mới nhất cho mỗi cặp tiền, bao gồm:
+   - Chênh lệch lạm phát tính theo điểm phần trăm.
+   - Lạm phát tích lũy của từng đồng tiền kể từ thời điểm bắt đầu.
+   - Tỷ giá quy đổi giữa hai đồng tiền và so sánh sức mua thực tế (USD).
+2. **Monthly Detail** – bảng chi tiết diễn biến theo từng tháng với các
+   chỉ số: chỉ số giá CPI, % lạm phát tích lũy, % lạm phát theo năm (YoY),
+   tỷ giá A/B và sức mua thực (USD) cho mỗi đồng trong cặp.
+3. **Sources** – liệt kê mã ticker tỷ giá trên Yahoo Finance và mã series CPI
+   từ FRED đã được sử dụng cho từng đồng tiền.

--- a/main.py
+++ b/main.py
@@ -201,7 +201,26 @@ def infer_cpi_series_id(fred: Fred, code: str, overrides: Mapping[str, str]) -> 
     """Determine the CPI series id for a currency using overrides or FRED search."""
 
     manual_defaults = {
+        # United States
         "USD": "CPIAUCNS",
+        # United Kingdom
+        "GBP": "GBRCPIALLMINMEI",
+        # Japan
+        "JPY": "JPNCPIALLMINMEI",
+        # Euro Area (Eurostat harmonised index)
+        "EUR": "CP0000EZ19M086NEST",
+        # Australia
+        "AUD": "AUSCPIALLMINMEI",
+        # Canada
+        "CAD": "CPALTT01CAM661N",
+        # Switzerland
+        "CHF": "CP0000CHM086NEST",
+        # China
+        "CNY": "CHNCPIALLMINMEI",
+        # South Korea
+        "KRW": "KORCPIALLMINMEI",
+        # Singapore
+        "SGD": "SGPCPIALLMINMEI",
     }
 
     if code in overrides:

--- a/main.py
+++ b/main.py
@@ -1,209 +1,441 @@
-# --- START OF FILE main_v3.py ---
+"""Currency inflation comparison tool.
 
-import yfinance as yf
-import pandas as pd
-from fredapi import Fred
+This script downloads FX rates from Yahoo Finance and CPI data from the
+Federal Reserve (FRED) to analyse the inflation-adjusted value of
+currency pairs.  The logic is optimised for the workflow described in the
+project README: the user only needs to provide the currency pairs and the
+script takes care of the rest.
+
+Example
+-------
+$ python main.py GBP-JPY
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from collections import Counter
 from datetime import datetime
-import sys
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 
-# --- CẤU HÌNH SCRIPT ---
+import pandas as pd
+import yfinance as yf
+from fredapi import Fred
 
-# 1. ĐẦU VÀO SIÊU ĐƠN GIẢN: Nhập các cặp tiền tệ bạn muốn so sánh.
-CURRENCY_PAIRS_TO_ANALYZE = [
-    "GBP-JPY",
-]
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
-# 2. CÁC THAM SỐ KHÁC
-START_AMOUNT_BASE_CURRENCY = 1000.0
-START_DATE = "2015-01-01"
-END_DATE = datetime.now().strftime('%Y-%m-%d')
-
-# THAY THẾ 'YOUR_FRED_API_KEY' BẰNG KEY CỦA BẠN
-FRED_API_KEY = 'd734a47c4d9113d7238034d16aa61bf0'
-
-OUTPUT_FILENAME = "currency_pair_comparison_for_charts.csv"
-
-# --- CƠ SỞ DỮ LIỆU TIỀN TỆ (Đã thêm USD) ---
-CURRENCY_DATABASE = {
-    "USD": {
-        "name": "Đô la Mỹ",
-        "fx_ticker": None, # Là tiền tệ cơ sở
-        "cpi_series": "CPIAUCNS", # CPI for United States
-        "region": "Bắc Mỹ",
-        "fx_type": "base"
-    },
-    "GBP": {
-        "name": "Bảng Anh",
-        "fx_ticker": "GBPUSD=X",
-        "cpi_series": "GBRCPIALLMINMEI",
-        "region": "Châu Âu",
-        "fx_type": "direct"
-    },
-}
-# --- KẾT THÚC CẤU HÌNH ---
+DEFAULT_START_DATE = "2015-01-01"
+START_AMOUNT_BASE_CURRENCY = 1_000.0
 
 
-def build_and_validate_job_list(pairs: list, db: dict) -> tuple:
-    """
-    Phân tích các cặp tiền, xác thực và tập hợp tất cả các yêu cầu dữ liệu.
-    """
-    print("0. Đang phân tích và xác thực các cặp tiền tệ...")
-    unique_currencies = set()
-    invalid_codes = []
+OUTPUT_FILENAME = "currency_inflation_comparison.xlsx"
 
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def parse_currency_pairs(pairs: Sequence[str]) -> List[str]:
+    """Normalise and validate the list of currency pairs provided by the user."""
+
+    formatted_pairs: List[str] = []
+    for raw_pair in pairs:
+        cleaned = raw_pair.strip().upper()
+        if not cleaned:
+            continue
+        if "-" not in cleaned:
+            raise ValueError(
+                f"Cặp tiền '{raw_pair}' không hợp lệ. Vui lòng sử dụng định dạng 'CUR1-CUR2'."
+            )
+        code_a, code_b = cleaned.split("-", maxsplit=1)
+        if len(code_a) != 3 or len(code_b) != 3:
+            raise ValueError(
+                f"Cặp tiền '{raw_pair}' không hợp lệ. Mỗi mã tiền phải gồm 3 ký tự."
+            )
+        formatted_pairs.append(f"{code_a}-{code_b}")
+
+    if not formatted_pairs:
+        raise ValueError("Bạn phải cung cấp ít nhất một cặp tiền tệ.")
+
+    return formatted_pairs
+
+
+def collect_currency_codes(pairs: Iterable[str]) -> List[str]:
+    """Return the unique currency codes that appear in the requested pairs."""
+
+    currencies: List[str] = []
     for pair in pairs:
-        codes = pair.split('-')
-        if len(codes) != 2:
-            print(f"\nLỖI: Cặp '{pair}' không hợp lệ. Phải có định dạng 'CUR1-CUR2'.")
-            return None, None, None
-        
-        for code in codes:
-            if code not in db:
-                invalid_codes.append(code)
-            unique_currencies.add(code)
+        for code in pair.split("-"):
+            if code not in currencies:
+                currencies.append(code)
+    return currencies
 
-    if invalid_codes:
-        print(f"\nLỖI: Không tìm thấy các mã tiền tệ sau: {', '.join(sorted(set(invalid_codes)))}")
-        print("Các mã được hỗ trợ bao gồm:", ", ".join(db.keys()))
-        return None, None, None
 
-    fx_tickers_needed = [db[c]['fx_ticker'] for c in unique_currencies if db[c]['fx_ticker']]
-    cpi_series_needed = {code: db[code]['cpi_series'] for code in unique_currencies}
-    
-    print("-> Xác thực thành công.")
-    print(f"-> Sẽ phân tích {len(pairs)} cặp tiền.")
-    print(f"-> Cần tải dữ liệu cho các đồng tiền: {', '.join(sorted(unique_currencies))}\n")
-    return list(unique_currencies), fx_tickers_needed, cpi_series_needed
+def parse_cpi_overrides(raw_overrides: Sequence[str]) -> Dict[str, str]:
+    """Convert CLI overrides of the form CODE=SERIES_ID into a dictionary."""
 
-def get_data(fx_tickers: list, cpi_map: dict, api_key: str, start: str, end: str) -> pd.DataFrame:
-    """Tải tất cả dữ liệu FX và CPI cần thiết."""
-    print("1. Đang tải tất cả dữ liệu cần thiết...")
-    try:
-        # Tải FX
-        fx_data = yf.download(fx_tickers, start=start, end=end, auto_adjust=True, progress=False)['Close']
-        if len(fx_tickers) == 1:
-            fx_data = fx_data.to_frame(name=fx_tickers[0])
-        fx_data.ffill(inplace=True)
+    overrides: Dict[str, str] = {}
+    for item in raw_overrides:
+        if "=" not in item:
+            raise ValueError(
+                f"Giá trị override '{item}' không hợp lệ. Định dạng đúng: CODE=SERIES_ID."
+            )
+        code, series_id = item.split("=", maxsplit=1)
+        code = code.strip().upper()
+        series_id = series_id.strip()
+        if len(code) != 3 or not series_id:
+            raise ValueError(
+                f"Giá trị override '{item}' không hợp lệ. Ví dụ hợp lệ: GBP=GBRCPIALLMINMEI."
+            )
+        overrides[code] = series_id
+    return overrides
 
-        # Tải CPI
-        fred = Fred(api_key=api_key)
-        cpi_df = pd.DataFrame()
-        for name, code in cpi_map.items():
-            series = fred.get_series(code, observation_start=start)
-            cpi_df[name] = series
-        cpi_daily = cpi_df.resample('D').ffill()
 
-        # Kết hợp
-        combined_df = fx_data.join(cpi_daily, how='inner').dropna()
-        print("-> Tải và kết hợp dữ liệu thành công.\n")
-        return combined_df
-    except Exception as e:
-        print(f"Lỗi khi tải dữ liệu: {e}")
-        return pd.DataFrame()
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Tự động tải dữ liệu và so sánh sức mua giữa các cặp tiền tệ.",
+    )
+    parser.add_argument(
+        "pairs",
+        nargs="*",
+        help="Danh sách các cặp tiền ở định dạng CUR1-CUR2 (vd: GBP-JPY EUR-USD).",
+    )
+    parser.add_argument(
+        "--start",
+        default=DEFAULT_START_DATE,
+        help="Ngày bắt đầu thu thập dữ liệu (YYYY-MM-DD). Mặc định: %(default)s",
+    )
+    parser.add_argument(
+        "--amount",
+        type=float,
+        default=START_AMOUNT_BASE_CURRENCY,
+        help="Số tiền ban đầu tính theo đồng tiền thứ nhất trong mỗi cặp. Mặc định: %(default).0f",
+    )
+    parser.add_argument(
+        "--fred-key",
+        default=os.getenv("FRED_API_KEY", ""),
+        help="API key của FRED. Mặc định sẽ đọc từ biến môi trường FRED_API_KEY nếu có.",
+    )
+    parser.add_argument(
+        "--output",
+        default=OUTPUT_FILENAME,
+        help="Tên file Excel đầu ra. Mặc định: %(default)s",
+    )
+    parser.add_argument(
+        "--cpi-series",
+        nargs="*",
+        default=[],
+        metavar="CODE=SERIES_ID",
+        help=(
+            "Ghi đè mã CPI cho từng đồng tiền nếu cần (ví dụ: GBP=GBRCPIALLMINMEI). "
+            "Hữu ích khi việc tìm kiếm tự động không cho kết quả mong muốn."
+        ),
+    )
+    return parser
 
-def get_usd_rate(df: pd.DataFrame, code: str, db: dict):
-    """Lấy tỷ giá hối đoái của một đồng tiền so với USD, xử lý fx_type."""
-    if code == 'USD':
-        return 1.0
-    
-    props = db[code]
-    ticker = props['fx_ticker']
-    fx_type = props['fx_type']
 
-    if fx_type == 'direct': # CUR/USD
-        return df[ticker]
-    elif fx_type == 'inverse': # USD/CUR
-        return 1 / df[ticker]
+def request_missing_arguments(args: argparse.Namespace) -> None:
+    """Prompt the user for missing mandatory arguments when running interactively."""
 
-def main():
-    print("--- SCRIPT SO SÁNH SỨC MUA GIỮA CÁC CẶP TIỀN TỆ ---")
+    if not args.pairs:
+        user_input = input(
+            "Nhập các cặp tiền tệ (ví dụ: GBP-JPY,EUR-USD): "
+        ).strip()
+        args.pairs = [part for part in user_input.replace(",", " ").split() if part]
 
-    # Bước 0: Xây dựng danh sách công việc từ đầu vào
-    currencies, fx_tickers, cpi_series = build_and_validate_job_list(CURRENCY_PAIRS_TO_ANALYZE, CURRENCY_DATABASE)
-    if not currencies:
-        sys.exit(1)
-    
-    if 'YOUR_FRED_API_KEY' in FRED_API_KEY or not FRED_API_KEY:
-        print("\nLỗi: Vui lòng thay thế 'YOUR_FRED_API_KEY' bằng API key thật của bạn từ FRED.")
-        return
+    if not args.fred_key:
+        args.fred_key = input("Nhập FRED API key của bạn: ").strip()
 
-    # Bước 1 & 2: Tải tất cả dữ liệu một lần
-    df = get_data(fx_tickers, cpi_series, FRED_API_KEY, START_DATE, END_DATE)
-    if df.empty:
-        print("Không thể tải dữ liệu cần thiết. Kết thúc chương trình.")
-        return
 
-    # Bước 3: Thực hiện tính toán cho từng cặp
-    print("3. Đang thực hiện tính toán cho từng cặp...")
-    results_df = pd.DataFrame(index=df.index)
+def load_usd_fx_rate(code: str, start_date: str, end_date: str) -> Tuple[pd.Series, str | None]:
+    """Download the USD exchange rate for a single currency."""
 
-    for pair in CURRENCY_PAIRS_TO_ANALYZE:
-        code_a, code_b = pair.split('-')
-        print(f"-> Đang xử lý cặp: {code_a}-{code_b}")
-        
-        # Lấy tỷ giá A/USD và B/USD tại ngày bắt đầu
-        start_rate_a_usd = get_usd_rate(df.iloc[0], code_a, CURRENCY_DATABASE)
-        start_rate_b_usd = get_usd_rate(df.iloc[0], code_b, CURRENCY_DATABASE)
-        
-        # Tính tỷ giá chéo A/B tại ngày bắt đầu
+    if code == "USD":
+        index = pd.date_range(start=start_date, end=end_date, freq="D")
+        return pd.Series(1.0, index=index, name=code), None
+
+    candidates: Tuple[Tuple[str, bool], ...] = (
+        (f"{code}USD=X", False),
+        (f"USD{code}=X", True),
+    )
+
+    for ticker, invert in candidates:
+        data = yf.download(ticker, start=start_date, end=end_date, auto_adjust=True, progress=False)
+        if not isinstance(data, pd.DataFrame) or "Close" not in data:
+            continue
+        series = data["Close"].dropna()
+        if series.empty:
+            continue
+        series.index = pd.to_datetime(series.index)
+        series = series.ffill().resample("D").ffill()
+        if invert:
+            series = 1 / series
+        series.name = code
+        return series, ticker
+
+    raise ValueError(f"Không thể tải dữ liệu tỷ giá USD cho mã tiền {code} từ Yahoo Finance.")
+
+
+def download_fx_data(currencies: Sequence[str], start_date: str, end_date: str) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    """Download USD exchange rates for all requested currencies."""
+
+    series_list: List[pd.Series] = []
+    sources: Dict[str, str] = {}
+
+    for code in currencies:
+        series, ticker = load_usd_fx_rate(code, start_date, end_date)
+        series_list.append(series)
+        if ticker:
+            sources[code] = ticker
+
+    fx_df = pd.concat(series_list, axis=1)
+    fx_df = fx_df.dropna()
+    if fx_df.empty:
+        raise ValueError("Không có dữ liệu tỷ giá sau khi tải và làm sạch.")
+
+    return fx_df, sources
+
+
+def infer_cpi_series_id(fred: Fred, code: str, overrides: Mapping[str, str]) -> str:
+    """Determine the CPI series id for a currency using overrides or FRED search."""
+
+    manual_defaults = {
+        "USD": "CPIAUCNS",
+    }
+
+    if code in overrides:
+        return overrides[code]
+    if code in manual_defaults:
+        return manual_defaults[code]
+
+    search_terms = [
+        f"{code} consumer price index all items",
+        f"{code} consumer price index",
+        f"{code} CPI",
+        code,
+    ]
+
+    for term in search_terms:
+        results = fred.search(term)
+        if results is None or results.empty:
+            continue
+
+        candidates = results.copy()
+        if "frequency" in candidates.columns:
+            candidates = candidates[candidates["frequency"].str.contains("Monthly", case=False, na=False)]
+        if "title" in candidates.columns:
+            title_mask = candidates["title"].str.contains("Consumer Price Index", case=False, na=False)
+            candidates = candidates[title_mask]
+            all_items_mask = candidates["title"].str.contains("All Items", case=False, na=False)
+            if all_items_mask.any():
+                candidates = candidates[all_items_mask]
+
+        if candidates.empty:
+            continue
+
+        sort_columns: List[Tuple[str, bool]] = []
+        if "popularity" in candidates.columns:
+            sort_columns.append(("popularity", False))
+        if "search_rank" in candidates.columns:
+            sort_columns.append(("search_rank", True))
+
+        if sort_columns:
+            columns, orders = zip(*sort_columns)
+            candidates = candidates.sort_values(list(columns), ascending=list(orders))
+
+        top_row = candidates.iloc[0]
+        if "id" in top_row:
+            return str(top_row["id"])
+        if "series_id" in top_row:
+            return str(top_row["series_id"])
+
+    raise ValueError(
+        f"Không thể tự động xác định mã CPI cho {code}. "
+        "Sử dụng tham số --cpi-series để chỉ định thủ công (ví dụ: GBP=GBRCPIALLMINMEI)."
+    )
+
+
+def download_cpi_series(
+    currencies: Sequence[str],
+    fred: Fred,
+    start_date: str,
+    overrides: Mapping[str, str],
+) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    """Download CPI series for all currencies and upsample to daily frequency."""
+
+    frames: List[pd.Series] = []
+    used_series: Dict[str, str] = {}
+
+    for code in currencies:
+        series_id = infer_cpi_series_id(fred, code, overrides)
+        series = fred.get_series(series_id, observation_start=start_date)
+        if series.empty:
+            raise ValueError(
+                f"Không tìm được dữ liệu CPI cho {code} với mã '{series_id}'."
+            )
+        series.index = pd.to_datetime(series.index)
+        series = series.ffill().resample("D").ffill()
+        series.name = code
+        frames.append(series)
+        used_series[code] = series_id
+
+    cpi_df = pd.concat(frames, axis=1)
+    cpi_df = cpi_df.dropna()
+    if cpi_df.empty:
+        raise ValueError("Không có dữ liệu CPI sau khi tải và làm sạch.")
+
+    return cpi_df, used_series
+
+
+def align_datasets(fx_df: pd.DataFrame, cpi_df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Return FX and CPI data aligned on a shared daily index."""
+
+    common_index = fx_df.index.intersection(cpi_df.index)
+    if common_index.empty:
+        raise ValueError(
+            "Không tìm thấy khoảng thời gian chung giữa dữ liệu tỷ giá và CPI. Kiểm tra ngày bắt đầu."
+        )
+
+    fx_aligned = fx_df.loc[common_index]
+    cpi_aligned = cpi_df.loc[common_index]
+    return fx_aligned, cpi_aligned
+
+
+def calculate_real_values(
+    fx_df: pd.DataFrame,
+    cpi_df: pd.DataFrame,
+    pairs: Sequence[str],
+    base_amount: float,
+) -> pd.DataFrame:
+    """Compute the inflation-adjusted USD value for each currency in every pair."""
+
+    if not fx_df.index.equals(cpi_df.index):
+        raise ValueError("Chỉ số thời gian của dữ liệu tỷ giá và CPI không khớp.")
+
+    results = pd.DataFrame(index=fx_df.index)
+    for pair in pairs:
+        code_a, code_b = pair.split("-")
+
+        daily_rate_a_usd = fx_df[code_a]
+        daily_rate_b_usd = fx_df[code_b]
+
+        start_rate_a_usd = daily_rate_a_usd.iloc[0]
+        start_rate_b_usd = daily_rate_b_usd.iloc[0]
         start_rate_a_b = start_rate_a_usd / start_rate_b_usd
-        
-        # Tính lượng tiền B ban đầu
-        initial_amount_b = START_AMOUNT_BASE_CURRENCY * start_rate_a_b
-        
-        # Lấy CPI cơ sở
-        base_cpi_a = df[code_a].iloc[0]
-        base_cpi_b = df[code_b].iloc[0]
+        initial_amount_b = base_amount * start_rate_a_b
 
-        # Tính sức mua thực tế theo đồng nội tệ
-        real_value_a = START_AMOUNT_BASE_CURRENCY / (df[code_a] / base_cpi_a)
-        real_value_b = initial_amount_b / (df[code_b] / base_cpi_b)
-        
-        # Chuẩn hóa về USD để so sánh
-        daily_rate_a_usd = get_usd_rate(df, code_a, CURRENCY_DATABASE)
-        daily_rate_b_usd = get_usd_rate(df, code_b, CURRENCY_DATABASE)
-        
-        # Lưu kết quả vào DataFrame chung
-        results_df[f'{pair}_{code_a}'] = real_value_a * daily_rate_a_usd
-        results_df[f'{pair}_{code_b}'] = real_value_b * daily_rate_b_usd
-    
-    print("-> Tính toán hoàn tất.\n")
+        base_cpi_a = cpi_df[code_a].iloc[0]
+        base_cpi_b = cpi_df[code_b].iloc[0]
 
-    # Bước 4: Định dạng kết quả cho Living Charts
-    print("4. Đang định dạng dữ liệu đầu ra...")
-    monthly_data = results_df.resample('M').last()
-    pivoted_data = monthly_data.transpose()
-    pivoted_data.columns = pivoted_data.columns.strftime('%Y-%m')
+        real_value_a = base_amount / (cpi_df[code_a] / base_cpi_a)
+        real_value_b = initial_amount_b / (cpi_df[code_b] / base_cpi_b)
 
-    # Tạo các cột metadata
-    names = []
-    groups = []
-    regions = []
-    for col_name in pivoted_data.index:
-        pair, code = col_name.split('_')
-        base_code = pair.split('-')[0]
-        if code == base_code:
-            names.append(f"Sức mua của {START_AMOUNT_BASE_CURRENCY:,.0f} {code}")
+        results[f"{pair}:{code_a}"] = real_value_a * daily_rate_a_usd
+        results[f"{pair}:{code_b}"] = real_value_b * daily_rate_b_usd
+
+    return results
+
+
+def format_for_excel(results_df: pd.DataFrame, pairs: Sequence[str]) -> pd.DataFrame:
+    """Pivot the results into the Excel-friendly format requested by the user."""
+
+    monthly = results_df.resample("M").last()
+    monthly.index = monthly.index.to_period("M").to_timestamp()
+
+    pivoted = monthly.transpose()
+    pivoted.columns = [col.strftime("%Y-%m") for col in pivoted.columns]
+
+    currency_usage = Counter(code for pair in pairs for code in pair.split("-"))
+
+    names: List[str] = []
+    images: List[str] = []
+    for raw_name in pivoted.index:
+        pair, code = raw_name.split(":")
+        if currency_usage[code] > 1:
+            display_name = f"{code} ({pair})"
         else:
-            names.append(f"Sức mua của lượng {code} tương đương")
-        groups.append(pair)
-        regions.append(CURRENCY_DATABASE[code]['region'])
-        
-    pivoted_data['Name'] = names
-    pivoted_data['Group'] = groups
-    pivoted_data['Region'] = regions
-    
-    date_columns = [col for col in pivoted_data.columns if col not in ['Name', 'Group', 'Region']]
-    final_df = pivoted_data[['Name', 'Group', 'Region'] + date_columns]
+            display_name = code
+        names.append(display_name)
+        images.append("")
+
+    pivoted.insert(0, "Image", images)
+    pivoted.insert(0, "Name", names)
+
+    return pivoted
+
+
+def save_to_excel(df: pd.DataFrame, filename: str) -> None:
+    """Persist the final dataframe to an Excel file."""
+
+    df.to_excel(filename, index=False)
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    request_missing_arguments(args)
 
     try:
-        final_df.to_csv(OUTPUT_FILENAME, index=False)
-        print(f"-> Hoàn tất! Dữ liệu đã được lưu vào file '{OUTPUT_FILENAME}'\n")
-    except Exception as e:
-        print(f"Lỗi khi lưu file CSV: {e}")
+        pairs = parse_currency_pairs(args.pairs)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return
 
-    print("--- QUÁ TRÌNH HOÀN TẤT ---")
+    if not args.fred_key:
+        parser.error("Bạn cần cung cấp FRED API key để chạy script.")
+        return
+
+    try:
+        cpi_overrides = parse_cpi_overrides(args.cpi_series)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return
+
+    currencies = collect_currency_codes(pairs)
+
+    print("\n--- BẮT ĐẦU QUY TRÌNH THU THẬP DỮ LIỆU ---")
+    print(f"Các cặp tiền được yêu cầu: {', '.join(pairs)}")
+    print(f"Sử dụng dữ liệu từ {args.start} tới hiện tại.")
+    print(f"Cần phân tích các đồng tiền: {', '.join(currencies)}\n")
+
+    end_date = datetime.now().strftime("%Y-%m-%d")
+    fred = Fred(api_key=args.fred_key)
+
+    fx_df, fx_sources = download_fx_data(currencies, args.start, end_date)
+    cpi_df, cpi_series = download_cpi_series(currencies, fred, args.start, cpi_overrides)
+    fx_aligned, cpi_aligned = align_datasets(fx_df, cpi_df)
+
+    print("Nguồn tỷ giá USD đã chọn:")
+    for code in currencies:
+        ticker = fx_sources.get(code)
+        if ticker:
+            print(f"  - {code}: {ticker}")
+        else:
+            print(f"  - {code}: USD (1.0)")
+    print("")
+
+    print("Mã CPI sử dụng:")
+    for code in currencies:
+        print(f"  - {code}: {cpi_series[code]}")
+    print("")
+
+    print("Hoàn tất tải dữ liệu. Bắt đầu tính toán...\n")
+
+    results = calculate_real_values(fx_aligned, cpi_aligned, pairs, args.amount)
+    formatted = format_for_excel(results, pairs)
+
+    save_to_excel(formatted, args.output)
+
+    print(f"Đã lưu kết quả vào file '{args.output}'.")
+    print("--- HOÀN THÀNH ---\n")
+
 
 if __name__ == "__main__":
     main()
-# --- END OF FILE main_v3.py ---


### PR DESCRIPTION
## Summary
- remove the static currency metadata and infer the required FX information by probing Yahoo Finance for USD exchange rates of the requested currencies
- discover CPI series identifiers via the FRED search API with optional CLI overrides and report the chosen FX/CPI sources during execution
- document the new `--cpi-series` override flag in the README to help users when automatic discovery is insufficient

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b5ca01fc8324a018da4e46b2869f